### PR TITLE
Pass bundle extras, allow to set notification color

### DIFF
--- a/OmetriaSDK/src/main/java/com/android/ometriasdk/core/Ometria.kt
+++ b/OmetriaSDK/src/main/java/com/android/ometriasdk/core/Ometria.kt
@@ -3,6 +3,7 @@ package com.android.ometriasdk.core
 import android.app.Application
 import android.content.Intent
 import android.net.Uri
+import android.os.Bundle
 import androidx.core.app.NotificationManagerCompat
 import androidx.lifecycle.ProcessLifecycleOwner
 import com.android.ometriasdk.core.Constants.Params.BASKET
@@ -78,7 +79,8 @@ class Ometria private constructor() : OmetriaNotificationInteractionHandler {
         fun initialize(
             application: Application,
             apiToken: String,
-            notificationIcon: Int
+            notificationIcon: Int,
+            notificationColor: Int
         ) = instance.also {
             it.ometriaConfig = OmetriaConfig(apiToken, application)
             it.localCache = LocalCache(application)
@@ -90,7 +92,7 @@ class Ometria private constructor() : OmetriaNotificationInteractionHandler {
             )
             it.eventHandler = EventHandler(application, it.repository)
             it.notificationHandler =
-                NotificationHandler(application, notificationIcon, it.executor)
+                NotificationHandler(application, notificationIcon, notificationColor, it.executor)
             it.isInitialized = true
             it.notificationInteractionHandler = instance
 
@@ -389,11 +391,12 @@ class Ometria private constructor() : OmetriaNotificationInteractionHandler {
         localCache.clearEvents()
     }
 
-    override fun onDeepLinkInteraction(deepLink: String) {
+    override fun onDeepLinkInteraction(deepLink: String, extras: Bundle?) {
         Logger.d(Constants.Logger.PUSH_NOTIFICATIONS, "Open URL: $deepLink")
         val intent = Intent(Intent.ACTION_VIEW)
         intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
         intent.data = Uri.parse(deepLink)
+        extras?.let { intent.putExtras(it) }
         ometriaConfig.application.startActivity(intent)
 
         trackDeepLinkOpenedEvent(deepLink, "Browser")

--- a/OmetriaSDK/src/main/java/com/android/ometriasdk/notification/NotificationHandler.kt
+++ b/OmetriaSDK/src/main/java/com/android/ometriasdk/notification/NotificationHandler.kt
@@ -24,12 +24,14 @@ const val KEY_OMETRIA = "ometria"
 internal class NotificationHandler(
     context: Context,
     notificationIcon: Int,
+    notificationColor: Int,
     private val executor: OmetriaThreadPoolExecutor,
 ) {
 
     private val ometriaPushNotification: OmetriaPushNotification = OmetriaPushNotification(
         context,
-        notificationIcon
+        notificationIcon,
+        notificationColor
     )
 
     /**

--- a/OmetriaSDK/src/main/java/com/android/ometriasdk/notification/OmetriaNotificationInteractionHandler.kt
+++ b/OmetriaSDK/src/main/java/com/android/ometriasdk/notification/OmetriaNotificationInteractionHandler.kt
@@ -1,5 +1,7 @@
 package com.android.ometriasdk.notification
 
+import android.os.Bundle
+
 /**
  * Created by cristiandregan
  * on 09/10/2020.
@@ -9,5 +11,5 @@ package com.android.ometriasdk.notification
  * An interface that allows you to control what happens when a user interacts with an Ometria originated push notification
  */
 interface OmetriaNotificationInteractionHandler {
-    fun onDeepLinkInteraction(deepLink: String)
+    fun onDeepLinkInteraction(deepLink: String, extras: Bundle?)
 }

--- a/OmetriaSDK/src/main/java/com/android/ometriasdk/notification/OmetriaPushNotification.kt
+++ b/OmetriaSDK/src/main/java/com/android/ometriasdk/notification/OmetriaPushNotification.kt
@@ -9,6 +9,7 @@ import android.graphics.Bitmap
 import android.os.Build
 import android.os.Bundle
 import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
 import com.android.ometriasdk.core.network.dataToJson
 
 /**
@@ -22,7 +23,8 @@ const val OMETRIA_CHANNEL_NAME = "ometria"
 
 internal class OmetriaPushNotification(
     private val context: Context,
-    private val notificationIcon: Int
+    private val notificationIcon: Int,
+    private val notificationColor: Int
 ) {
 
     fun createPushNotification(
@@ -46,6 +48,7 @@ internal class OmetriaPushNotification(
             .setAutoCancel(true)
             .setContentIntent(contentIntent)
             .setLargeIcon(image)
+            .setColor(ContextCompat.getColor(context, notificationColor))
 
         val notificationManager =
             context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager

--- a/OmetriaSDK/src/main/java/com/android/ometriasdk/notification/PushClickBroadcastReceiver.kt
+++ b/OmetriaSDK/src/main/java/com/android/ometriasdk/notification/PushClickBroadcastReceiver.kt
@@ -28,10 +28,11 @@ internal class PushClickBroadcastReceiver : BroadcastReceiver() {
         if (action != null && action == PUSH_TAP_ACTION && context != null) {
             val deepLinkActionUrl = intent.getStringExtra(NOTIFICATION_ACTION_URL_KEY)
             if (deepLinkActionUrl != null && URLUtil.isValidUrl(deepLinkActionUrl)) {
-                Ometria.instance().notificationInteractionHandler.onDeepLinkInteraction(deepLinkActionUrl)
+                Ometria.instance().notificationInteractionHandler.onDeepLinkInteraction(deepLinkActionUrl, intent.extras)
             } else {
                 val launcherIntent = context.packageManager.getLaunchIntentForPackage(context.packageName)
                 launcherIntent?.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                intent.extras?.let { launcherIntent?.putExtras(it) }
                 context.startActivity(launcherIntent)
             }
 

--- a/app/src/main/java/com/android/sample/SampleApp.kt
+++ b/app/src/main/java/com/android/sample/SampleApp.kt
@@ -3,6 +3,7 @@ package com.android.sample
 import android.app.Application
 import android.content.Intent
 import android.net.Uri
+import android.os.Bundle
 import android.util.Log
 import com.android.ometriasdk.core.Ometria
 import com.android.ometriasdk.notification.OmetriaNotificationInteractionHandler
@@ -35,7 +36,7 @@ class SampleApp : Application(), OmetriaNotificationInteractionHandler {
         Ometria.instance().notificationInteractionHandler = this
     }
 
-    override fun onDeepLinkInteraction(deepLink: String) {
+    override fun onDeepLinkInteraction(deepLink: String, extras: Bundle?) {
         Log.d(SampleApp::class.java.simpleName, "Open URL: $deepLink")
         Ometria.instance().trackDeepLinkOpenedEvent(deepLink, "Browser")
 


### PR DESCRIPTION
This PR includes 2 changes:
- ability to change the notification color
- Include original bundle extras in the intent generated so they can be used for analytics purposes, etc.